### PR TITLE
Breakage in CASA dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "simms"
-version = "2.0.0"
+version = "2.0.1"
 description = "Empty MS creation tool"
 authors = ["Sphesihle Makhathini <sphemakh@gmail.com>"]
 license = "GPL2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,9 @@ homepage="https://github.com/radio-astro/simms"
 [tool.poetry.dependencies]
 python = "^3.6"
 numpy = "*"
-casatasks = "*"
-casatools = "*"
+# Breakage in handling of system-wide ephem directories in casa 6.6.3 and beyond
+casatasks = "<6.6.3"
+casatools = "<6.6.3"
 
 [tool.poetry.scripts]
 simms = "simms.core:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ homepage="https://github.com/radio-astro/simms"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-numpy = "*"
+numpy = "<2.0"
 # Breakage in handling of system-wide ephem directories in casa 6.6.3 and beyond
 casatasks = "<6.6.3"
 casatools = "<6.6.3"


### PR DESCRIPTION
The latest CASAtools/tasks release fails to correctly import data distributed by casacore-data debian packages. This downgrades the dependency on CASA to a last known working version